### PR TITLE
Fix mounting images in affiliation directory into DOMjudge

### DIFF
--- a/domjudge/docker-compose.yml
+++ b/domjudge/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     ports:
       - 12345:80
     volumes:
-      - ${PWD}/affilDOMjudge:/opt/domjudge/domserver/webapp/public/images/affiliations
+      - ${PWD}/../affiliation:/opt/domjudge/domserver/webapp/public/images/affiliations
   #  entrypoint: ["/bin/bash","-c","sleep 1m && /scripts/start.sh"]
   #  hostname: domserver
   #  #privileged: true


### PR DESCRIPTION
To test #11, I've (successfully) imported `organizations.json` and `teams.json` into DOMjudge. However, this required me to fix the mount path in `domjudge/docker-compose.yml`, see the commit in this draft PR. 

Even with this fix, the affiliation logos still did not show up properly. It looks like the affiliations need to be stored in `public/images/affiliations/<id>.png`, as explained [here](https://www.domjudge.org/docs/manual/8.3/config-advanced.html#adding-graphics-custom-styling-and-custom-javascript). However, we currently have the university logos stored as `affiliation/<id>/{64,256}.png`. By manually copying one logo from `affiliation/<id>/256.png` to `affiliation/<id>.png`, and setting the data source configuration setting to "configuration data external", I've confirmed that it _does_ show up in DOMjudge. (Note that "configuration data external" will become the default in 8.4, and the numeric internal IDs will no longer be exposed in any way.)

We should either:
1. Only store the 256px logos, in the correct folder structure for DOMjudge
2. Have some automation that generates the correct folder structure for DOMjudge

I prefer option 1, but perhaps the 64px logos are used somewhere that I'm not aware of. Other thoughts? :slightly_smiling_face: 