### PR TITLE
Bump versions in GitHub Actions workflow

### DIFF
--- a/.github/workflows/zip-release.yml
+++ b/.github/workflows/zip-release.yml
@@ -8,10 +8,10 @@ on:
 jobs:
   release:
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Zip logos for domjudge
         run: cd ${{ github.workspace }}; mkdir out;cd organizations; for f in *; do cp "$f/logo.64x64.png" "../out/$f.64.png"; done; cd ../out; zip -r domjudge.zip *.png;
       - name: Zip logos for cds


### PR DESCRIPTION
`actions/checkout@v2` runs on Node 12, which has loooong been deprecated :stuck_out_tongue: 

Also, changing `runs-on` to `ubuntu-latest`, so that we don't have to update this every two years and the commands used aren't super-duper Ubuntu-version-dependent :slightly_smiling_face: 